### PR TITLE
Compare with 1 (true) instead of 0 (false)

### DIFF
--- a/llist.c
+++ b/llist.c
@@ -98,7 +98,7 @@ llist_find_custom (LList      *list,
 {
 	while (list)
 	{
-		if (func (list->data, udata) == 0)
+		if (func (list->data, udata) == 1)
 			return list->data;
 		
 		list = list->next;


### PR DESCRIPTION
Somehow i missed this little bug, in C the value **0** represents **false**.